### PR TITLE
add requestTimestamp to MinimalResponseHandler

### DIFF
--- a/spec/support/mocks/unifier/handler.ts
+++ b/spec/support/mocks/unifier/handler.ts
@@ -1,10 +1,11 @@
-import { MinimalResponseHandler } from "../../../../src/components/unifier/public-interfaces";
+import { inject, injectable } from "inversify";
 import { RequestContext } from "../../../../src/components/root/public-interfaces";
-import { injectable, inject } from "inversify";
+import { MinimalResponseHandler } from "../../../../src/components/unifier/public-interfaces";
 
 @injectable()
 export class ResponseHandler implements MinimalResponseHandler {
   endSession: boolean = false;
+  requestTimestamp: Date = new Date();
   voiceMessage: string = "";
   sendResponse() {}
 }

--- a/src/components/unifier/abstract-response-handler.ts
+++ b/src/components/unifier/abstract-response-handler.ts
@@ -1,20 +1,31 @@
-import { inject, injectable, multiInject, optional } from "inversify";
+import {
+  inject,
+  injectable,
+  multiInject,
+  optional
+  } from "inversify";
 import { ExecutableExtension } from "inversify-components";
 import * as util from "util";
-
 import { RequestContext, ResponseCallback } from "../root/public-interfaces";
 import { componentInterfaces } from "./private-interfaces";
-import { AfterResponseHandler, BeforeResponseHandler, MinimalResponseHandler, ResponseHandlerExtensions } from "./public-interfaces";
+import {
+  AfterResponseHandler,
+  BeforeResponseHandler,
+  MinimalResponseHandler,
+  ResponseHandlerExtensions
+  } from "./public-interfaces";
+
 
 @injectable() /** Take this class as base class for implementing response handler, if needed */
 export abstract class AbstractResponseHandler implements MinimalResponseHandler {
   public endSession: boolean;
   public voiceMessage: string | null = null;
-
+  public requestTimestamp: Date;
   public responseCallback: ResponseCallback;
   public killSession: () => Promise<void>;
 
   private canSendResponse: boolean = true;
+
 
   constructor(
     @inject("core:root:current-request-context") extraction: RequestContext,

--- a/src/components/unifier/public-interfaces.ts
+++ b/src/components/unifier/public-interfaces.ts
@@ -310,6 +310,8 @@ export interface MinimalResponseHandler {
   endSession: boolean;
   /** Voice message to speak to the user */
   voiceMessage: string | null;
+  /** Request timestamp from request body. Timestamp is provided as an ISO 8601 formatted string (for example, 2015-05-13T12:34:56Z). */
+  requestTimestamp: Date;
   /** Called automatically if the response should be sent */
   sendResponse(): void;
 }


### PR DESCRIPTION
Add a request timestamp to the MinimalResponseHandler.

Allows you to set the provider("Amazon/Google") specific request timestamp in the `AlexaHandle` and `ApiAiHandle`.