### PR TITLE
adds missing decorators exports

### DIFF
--- a/src/assistant-source.ts
+++ b/src/assistant-source.ts
@@ -35,3 +35,8 @@ export type Constructor<T> = new (...args: any[]) => T;
 export interface Mixin<T> {
   new (...args: any[]): T;
 }
+
+// Export decorators
+export { stayInContext } from "./components/state-machine/decorators/stay-in-context-decorator";
+export { clearContext } from "./components/state-machine/decorators/clear-context-decorator";
+export { filter } from "./components/state-machine/filter-decorator";


### PR DESCRIPTION
adds missing exports for `stayInContext`, `clearContext` and `filter` decorators