### PR TITLE
Modifies `package-lock.json` to load newer version of `lodash`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2847,7 +2847,7 @@
       "dev": true,
       "requires": {
         "glob": "~3.1.21",
-        "lodash": "~1.0.1",
+        "lodash": "~1.3.1",
         "minimatch": "~0.2.11"
       },
       "dependencies": {
@@ -2875,9 +2875,9 @@
           "dev": true
         },
         "lodash": {
-          "version": "1.0.2",
-          "resolved": "http://sinopia.verstehe.local:4873/lodash/-/lodash-1.0.2.tgz",
-          "integrity": "sha1-j1dWDIO1n8JwvT1WG2kAQ0MOJVE=",
+          "version": "1.3.1",
+	  "resolved": "http://sinopia.verstehe.local:4873/lodash/-/lodash-1.3.1.tgz",
+          "integrity": "sha1-pGY7U2hriV/wdOK6UE37dqjit3A=",
           "dev": true
         },
         "minimatch": {


### PR DESCRIPTION
This isn't necessarily for merging, rather as a hint how we could upgrade gulp dependencies. 