### PR TITLE
Feature/default ts translations

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,7 +4,7 @@ version 0.5.0
 - adds option to UniferConfiguration that allows to change the way how request extractors are found.
 - adds option to pass component's defaultConfiguration a function that returns a new configuration object
 - passes list of components to except from autobind to inversify-components
-- loads all TypeScript, JavaScript and JSON files from locales directory, if not i18next backend is configured
+- Loads all TypeScript, JavaScript and JSON files from locales directory, if i18next backend is not configured. `.ts` files shadow `.js` files, `.js` files shadow `.json` files. The folder/file structure is resembled in the final locales object, while the filenames are camelcased, i.e. a folder `main-state` will be a key `mainState`, which will contain all content from that folder. If LocalesLoader finds an ES6 default export or an export the same name as the camelcased file name, only this is taken from the file. In any other case, everything is exported. Files and folders of the same name are merged. An example can be found [here](https://gist.github.com/baflo/b88e636948b6b57c3f07af2672088961).
 
 version 0.4.1
 - fixes typing of StayInContextCallback and ClearContextCallback

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@ version 0.5.0
 - adds option to UniferConfiguration that allows to change the way how request extractors are found.
 - adds option to pass component's defaultConfiguration a function that returns a new configuration object
 - passes list of components to except from autobind to inversify-components
+- loads all TypeScript, JavaScript and JSON files from locales directory, if not i18next backend is configured
 
 version 0.4.1
 - fixes typing of StayInContextCallback and ClearContextCallback

--- a/package-lock.json
+++ b/package-lock.json
@@ -2102,14 +2102,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2124,20 +2122,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2254,8 +2249,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2267,7 +2261,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2282,7 +2275,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2290,14 +2282,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2316,7 +2306,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2397,8 +2386,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2410,7 +2398,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2532,7 +2519,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2102,12 +2102,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2122,17 +2124,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2249,7 +2254,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2261,6 +2267,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2275,6 +2282,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2282,12 +2290,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2306,6 +2316,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2386,7 +2397,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2398,6 +2410,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2519,6 +2532,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3578,12 +3592,11 @@
       "integrity": "sha1-qV7bNK4IK7EXUzbVHc1fARE0xiU="
     },
     "inversify-components": {
-      "version": "0.4.5",
-      "resolved": "http://sinopia.verstehe.local:4873/inversify-components/-/inversify-components-0.4.5.tgz",
-      "integrity": "sha512-vIMOaOwlvd4GtnrkYkjYTj/2j9IynOfRb6BmFBsUxxrAW8WvJ3szJjjjvhPy8SO6T9phLz75Y26wwV4Krd+CUw==",
+      "version": "0.4.6",
+      "resolved": "http://sinopia.verstehe.local:4873/inversify-components/-/inversify-components-0.4.6.tgz",
+      "integrity": "sha512-NNAnbG1poHauvHZ7pqAINDTutxorK7eZxmH5NPsYgdjcFuDcESApkRIlGFlN1GVXHcCHuesH3+S1FZQmNbPv5Q==",
       "requires": {
-        "debug": "^3.1.0",
-        "lodash": "^4.17.11"
+        "debug": "^3.1.0"
       },
       "dependencies": {
         "debug": {
@@ -8277,8 +8290,7 @@
     "require-directory": {
       "version": "2.1.1",
       "resolved": "http://sinopia.verstehe.local:4873/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
-      "dev": true
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
     },
     "require-main-filename": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "lodash": "^4.17.11",
     "redis": "2.8.0",
     "reflect-metadata": "^0.1.12",
+    "require-directory": "^2.1.1",
     "resolve": "^1.8.1",
     "rxjs": "^5.5.11"
   },

--- a/scaffold/components.ts.scaffold
+++ b/scaffold/components.ts.scaffold
@@ -17,10 +17,12 @@ const configuration: AssistantJSConfiguration = {
   "core:i18n": {
     // This is basically the i18next configuration. Check out https://www.i18next.com/ for more information!
     i18nextAdditionalConfiguration: {
-      // This entry is needed and tells i18next where to find your language files.
-      backend: {
-        loadPath: process.cwd() + "/config/locales/{{lng}}/{{ns}}.json",
-      },
+      // Translation resources are automatically loaded from path given in `UnifierConfiguration#utterancePath`, but may be overridden here.
+      // resources: {}
+      // Alternatively you can give a path to a folder with JSON files that can be loaded by i18next
+      // backend: {
+      //   loadPath: process.cwd() + "/config/locales/{{lng}}/{{ns}}.json",
+      // },
       lngs: ["en"],
       fallbackLng: "en",
       // If you encouter problems with i18next, change this to true

--- a/spec/components/i18n/wrapper.spec.ts
+++ b/spec/components/i18n/wrapper.spec.ts
@@ -1,8 +1,11 @@
+import * as path from "path";
+
 import { TEMPORARY_INTERPOLATION_END, TEMPORARY_INTERPOLATION_START } from "../../../src/components/i18n/interpolation-resolver";
 import { arraySplitter } from "../../../src/components/i18n/plugins/array-returns-sample.plugin";
 import { I18nextWrapper } from "../../../src/components/i18n/wrapper";
 import { injectionNames } from "../../../src/injection-names";
 import { configureI18nLocale } from "../../support/util/i18n-configuration";
+import { configureUnifier } from "../../support/util/unifier-configuration";
 import { ThisContext } from "../../this-context";
 
 interface CurrentThisContext extends ThisContext {
@@ -53,6 +56,44 @@ describe("I18nWrapper", function() {
         this.wrapper = this.inversify.get(injectionNames.i18nSpecWrapper);
         expect(this.wrapper.instance.t("templateSyntaxSmall", { name: "my name" })).toEqual(expectedTranslations.join(arraySplitter));
       });
+    });
+  });
+});
+
+describe("I18nWrapper loading Typescript files", function(this: CurrentThisContext) {
+  const expectedTranslations = ["hello my name", "hi my name", "welcome my name"];
+
+  beforeEach(function(this: CurrentThisContext) {
+    this.specHelper.prepareSpec(this.defaultSpecOptions);
+    // Remove emitting of warnings
+    this.specHelper.bindSpecLogger("error");
+
+    configureI18nLocale(this.assistantJs.container, false);
+    configureUnifier(this.assistantJs.container, path.join(__dirname, "../../support/mocks/i18n-ts/locale/"));
+    this.wrapper = this.inversify.get("core:i18n:wrapper");
+  });
+
+  describe("translation function", function() {
+    it("returns one of many options", function(this: CurrentThisContext) {
+      expect(expectedTranslations).toContain(this.wrapper.instance.t("templateSyntaxSmall", { name: "my name" }));
+    });
+  });
+
+  describe("loading behaviour", function() {
+    it("load from file that has the same name as a directory", function() {
+      expect(this.wrapper.instance.store.data.de.translation.mySpecificKeys.keyOne).toBe("keyOneResult");
+    });
+
+    it("loads default only if exists", function() {
+      expect(this.wrapper.instance.store.data.de.translation.defaultExport.test).toBe("default");
+    });
+
+    it("loads export with camelcase filename if no default exists", function() {
+      expect(this.wrapper.instance.store.data.de.translation.templateSyntaxSmall[0]).toBe("{hello|hi} {{name}}");
+    });
+
+    it("loads all exports if neither default nor one equal to camelcase filename exists", function() {
+      expect(this.wrapper.instance.store.data.de.translation.mainState.testIntent.embedded.test).toBe("very-specific-without-extractor");
     });
   });
 });

--- a/spec/components/unifier/locales-loader.spec.ts
+++ b/spec/components/unifier/locales-loader.spec.ts
@@ -102,7 +102,7 @@ describe("LocalesLoader", function() {
       });
     });
 
-    it("prioritizes JS files over JSON files", function(this: CurrentThisContext) {
+    fit("prioritizes JS files over JSON and TS over JS and JSON files", function(this: CurrentThisContext) {
       const entities = this.localesLoader.getCustomEntities();
       const utterances = this.localesLoader.getUtteranceTemplates();
 

--- a/spec/components/unifier/locales-loader.spec.ts
+++ b/spec/components/unifier/locales-loader.spec.ts
@@ -102,7 +102,7 @@ describe("LocalesLoader", function() {
       });
     });
 
-    fit("prioritizes JS files over JSON and TS over JS and JSON files", function(this: CurrentThisContext) {
+    it("prioritizes JS files over JSON and TS over JS and JSON files", function(this: CurrentThisContext) {
       const entities = this.localesLoader.getCustomEntities();
       const utterances = this.localesLoader.getUtteranceTemplates();
 

--- a/spec/components/unifier/locales-loader.spec.ts
+++ b/spec/components/unifier/locales-loader.spec.ts
@@ -2,14 +2,13 @@ import * as fs from "fs";
 import { Component, getMetaInjectionName } from "inversify-components";
 import { resolve } from "path";
 import { LocalesLoader, UnifierConfiguration } from "../../../src/assistant-source";
-import { Configuration } from "../../../src/components/unifier/private-interfaces";
 import { injectionNames } from "../../../src/injection-names";
 import { ThisContext } from "../../this-context";
 
 // tslint:disable no-var-requires
 const deUtterances = require("../../support/mocks/i18n/locale/de/utterances.json");
-const enUtterances = require("../../support/mocks/i18n/locale/en/utterances.js");
-const deEntities = require("../../support/mocks/i18n/locale/de/entities.json");
+const enUtterances = require("../../support/mocks/i18n/locale/en/utterances.ts");
+const { default: deEntities } = require("../../support/mocks/i18n/locale/de/entities.ts");
 const enEntities = require("../../support/mocks/i18n/locale/en/entities.js");
 // tslint:enable no-var-requires
 
@@ -121,7 +120,7 @@ describe("LocalesLoader", function() {
     });
   });
 
-  describe("getUtteranceTemplates", function() {
+  describe("#getUtteranceTemplates", function() {
     it("loads all utterance templates of all languages from file system", function(this: CurrentThisContext) {
       const utterances = this.localesLoader.getUtteranceTemplates();
 
@@ -133,7 +132,7 @@ describe("LocalesLoader", function() {
     });
   });
 
-  describe("getCustomEntities", function() {
+  describe("#getCustomEntities", function() {
     it("loads all custom entities of all languages from file system", function(this: CurrentThisContext) {
       const entities = this.localesLoader.getCustomEntities();
 

--- a/spec/support/mocks/i18n-ts/locale/de/translation.ts
+++ b/spec/support/mocks/i18n-ts/locale/de/translation.ts
@@ -1,0 +1,56 @@
+export default {
+  mySpecificKeys: {
+    keyOne: "keyOneResult",
+  },
+  multiple: ["a", "b"],
+  var: "a{{var}}",
+  multipleVars: "a{{firstVar}}b{{secondVar}}c{{thirdVar}}",
+  deviceDependentState: {
+    ExtractorComponent: {
+      device1: "state-platform-device-specific",
+    },
+  },
+  root: {
+    testIntent: {
+      embedded: {
+        platformDependent: {
+          ExtractorComponent: "platform-specific-embedded",
+        },
+        platformIndependent: "platform-independent-root-embedded",
+      },
+      withoutExtractor: "root-without-extractor",
+      deviceDependent: {
+        ExtractorComponent: {
+          device1: "root-intent-platform-device-specific",
+        },
+      },
+    },
+    secondPlatformSpecificIntent: {
+      ExtractorComponent: "root-platform-specific-intent",
+    },
+    yesGenericIntent: "root-yes",
+    rootKey: {
+      ExtractorComponent: "platform-specific-root-only",
+    },
+    ExtractorComponent: "root-only-platform-given",
+  },
+  noIntentState: "stateOnly",
+  templateSyntax: ["{Can|May} I help you, {{var}}?", "Would you like me to help you?"],
+  filter: {
+    stateA: {
+      intentA: "FilterAState - filterTestAIntent",
+      intentB: "FilterAState - filterTestBIntent",
+      intentC: "FilterAState - filterTestCIntent",
+      intentD: "FilterAState - filterTestDIntent",
+    },
+    stateB: {
+      intentA: "FilterBState - filterTestAIntent",
+      intentB: "FilterBState - filterTestBIntent",
+    },
+    stateC: {
+      intentA: "FilterCState - filterTestAIntent",
+      intentB: "FilterCState - filterTestBIntent",
+    },
+  },
+  noInterpolation: "no interpolation",
+};

--- a/spec/support/mocks/i18n-ts/locale/de/translation/default-export.ts
+++ b/spec/support/mocks/i18n-ts/locale/de/translation/default-export.ts
@@ -1,0 +1,2 @@
+export const someState = { some: "state" };
+export default { test: "default" };

--- a/spec/support/mocks/i18n-ts/locale/de/translation/main-state.ts
+++ b/spec/support/mocks/i18n-ts/locale/de/translation/main-state.ts
@@ -1,0 +1,32 @@
+export const testIntent = {
+  embedded: {
+    test: "very-specific-without-extractor",
+    platformDependent: {
+      ExtractorComponent: "platform-specific-sub-key",
+    },
+  },
+};
+
+export const deviceDependentIntent = {
+  embeddedKeyOuter: {
+    embeddedKeyInner: {
+      ExtractorComponent: {
+        device1: "device-specific-sub-key",
+      },
+    },
+  },
+};
+
+export const yesGenericIntent = "yes";
+
+export const platformDependent = {
+  ExtractorComponent: "platform-specific-embedded-state-only",
+};
+
+export const platformIndependent = "platform-independent-main-state";
+
+export const ExtractorComponent = "platform-specific-main-state-only";
+
+export const platformSpecificIntent = {
+  ExtractorComponent: "platform-specific-intent",
+};

--- a/spec/support/mocks/i18n-ts/locale/de/translation/template-syntax-small.ts
+++ b/spec/support/mocks/i18n-ts/locale/de/translation/template-syntax-small.ts
@@ -1,0 +1,1 @@
+export const templateSyntaxSmall = ["{hello|hi} {{name}}", "welcome {{name}}"];

--- a/spec/support/mocks/i18n/locale/de/entities.json
+++ b/spec/support/mocks/i18n/locale/de/entities.json
@@ -1,16 +1,3 @@
 {
-  "color": [
-    {
-      "value": "grün",
-      "synonyms": ["waldgrün", "salbei", "oliv", "limone", "jade", "minz"]
-    },
-    {
-      "value": "rot",
-      "synonyms": ["scharlach", "lachs", "karmin", "ziegel", "rubin", "blut"]
-    },
-    {
-      "value": "gelb",
-      "synonyms": ["kanariengelb", "flachs", "mais", "honig", "bernstein", "blond"]
-    }
-  ]
+  "this should be shadowed by entities.ts": true
 }

--- a/spec/support/mocks/i18n/locale/de/entities.ts
+++ b/spec/support/mocks/i18n/locale/de/entities.ts
@@ -1,0 +1,16 @@
+export default {
+  color: [
+    {
+      value: "grün",
+      synonyms: ["waldgrün", "salbei", "oliv", "limone", "jade", "minz"],
+    },
+    {
+      value: "rot",
+      synonyms: ["scharlach", "lachs", "karmin", "ziegel", "rubin", "blut"],
+    },
+    {
+      value: "gelb",
+      synonyms: ["kanariengelb", "flachs", "mais", "honig", "bernstein", "blond"],
+    },
+  ],
+};

--- a/spec/support/mocks/i18n/locale/en/utterances.js
+++ b/spec/support/mocks/i18n/locale/en/utterances.js
@@ -1,3 +1,3 @@
 module.exports = {
-  testIntent: ["This is a test", "A second test utterances"],
-};
+  "this should be shadowed by utterances.ts": true
+}

--- a/spec/support/mocks/i18n/locale/en/utterances.json
+++ b/spec/support/mocks/i18n/locale/en/utterances.json
@@ -1,3 +1,3 @@
 {
-  "this should be shadowed by utterances.ts": true
+  "this should be shadowed by utterances.js": true
 }

--- a/spec/support/mocks/i18n/locale/en/utterances.ts
+++ b/spec/support/mocks/i18n/locale/en/utterances.ts
@@ -1,0 +1,3 @@
+module.exports = {
+  testIntent: ["This is a test", "A second test utterances"],
+};

--- a/spec/support/mocks/unifier/mock-locale-loader.ts
+++ b/spec/support/mocks/unifier/mock-locale-loader.ts
@@ -27,4 +27,12 @@ export class LocalesLoaderMock implements LocalesLoader {
       },
     };
   }
+
+  public getTranslations() {
+    return {};
+  }
+
+  public getLocales() {
+    return undefined;
+  }
 }

--- a/spec/support/util/unifier-configuration.ts
+++ b/spec/support/util/unifier-configuration.ts
@@ -1,0 +1,11 @@
+import * as i18next from "i18next";
+import { Container } from "inversify-components";
+import { UnifierConfiguration } from "../../../src/assistant-source";
+
+export function configureUnifier(container: Container, utterancePath: string) {
+  const config: UnifierConfiguration = {
+    utterancePath,
+  };
+
+  container.componentRegistry.lookup("core:unifier").addConfiguration(config);
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,6 +10,7 @@ import * as commander from "commander";
 // Import node.js filesystem module
 import * as fs from "fs";
 import { Component } from "inversify-components";
+import * as path from "path";
 import { AssistantJSApplicationInitializer } from "./components/joined-interfaces";
 
 // Get package.json data
@@ -63,6 +64,8 @@ export function cli(argv, resolvedApplicationInitializer) {
       "config",
       "config/locales",
       "config/locales/en",
+      "config/locales/en/translation",
+      "config/locales/en/utterances",
       "spec",
       "spec/app",
       "spec/app/states",
@@ -104,10 +107,21 @@ export function cli(argv, resolvedApplicationInitializer) {
       fs.closeSync(fs.openSync(projectPath + touchableFile, "w"));
     });
 
-    // Create empty json files
-    ["config/locales/en/translation.json", "config/locales/en/utterances.json"].forEach(filePath => {
+    // Create base TypesScript files
+    ["config/locales/en/translation/main-state.ts"].forEach(filePath => {
       console.log("Creating " + filePath + "..");
-      fs.writeFileSync(projectPath + filePath, "{}");
+      fs.writeFileSync(
+        projectPath + filePath,
+        `export const ${path.basename(filePath, path.extname(filePath)).replace(/[\-]+([a-z])/gi, (m, c) => c.toUpperCase())} = {};`
+      );
+    });
+
+    ["config/locales/en/utterances/invokeGenericIntent.ts"].forEach(filePath => {
+      console.log("Creating " + filePath + "..");
+      fs.writeFileSync(
+        projectPath + filePath,
+        `export const ${path.basename(filePath, path.extname(filePath)).replace(/[\-]+([a-z])/gi, (m, c) => c.toUpperCase())} = [];`
+      );
     });
   };
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -48,8 +48,8 @@ export function cli(argv, resolvedApplicationInitializer) {
   /** Initializes new assistantjs project (prototyped currently) */
   const createProject = function(name: string) {
     // Path to new project
-    const projectPath = process.cwd() + "/" + name + "/";
-    const scaffoldDir = __dirname + "/../scaffold/";
+    const projectPath = `${path.resolve(name)}/`;
+    const scaffoldDir = `${path.join(__dirname, "/../scaffold")}/`;
 
     // Create directories
     console.log("Creating project directory..");
@@ -72,7 +72,7 @@ export function cli(argv, resolvedApplicationInitializer) {
       "spec/helpers",
       "spec/support",
     ].forEach(directory => {
-      console.log("Creating " + directory + "..");
+      console.log(`Creating ${directory} ..`);
       fs.mkdirSync(projectPath + directory);
     });
 
@@ -97,22 +97,22 @@ export function cli(argv, resolvedApplicationInitializer) {
 
     // Copy templates!
     copyInstructions.forEach(copyInstruction => {
-      console.log("Creating " + copyInstruction[1] + "..");
-      copyAndReplace(name, scaffoldDir + copyInstruction[0] + ".scaffold", projectPath + copyInstruction[1]);
+      console.log(`Creating ${copyInstruction[1]} ..`);
+      copyAndReplace(name, `${scaffoldDir}${copyInstruction[0]}.scaffold`, projectPath + copyInstruction[1]);
     });
 
     // Create empty files
     ["builds/.keep"].forEach(touchableFile => {
-      console.log("Touching " + touchableFile + "..");
+      console.log(`Touching ${touchableFile} ..`);
       fs.closeSync(fs.openSync(projectPath + touchableFile, "w"));
     });
 
     // Create base TypesScript files
     [
       { filePath: "config/locales/en/translation/main-state.ts", exportString: "{}" },
-      { filePath: "config/locales/en/utterances/invokeGenericIntent.ts", exportString: "[]" },
+      { filePath: "config/locales/en/utterances/invoke-generic-intent.ts", exportString: "[]" },
     ].forEach(({ filePath, exportString }) => {
-      console.log("Creating " + filePath + "..");
+      console.log(`Creating ${filePath} ...`);
       fs.writeFileSync(
         projectPath + filePath,
         `export const ${path.basename(filePath, path.extname(filePath)).replace(/[\-]+([a-z])/gi, (m, c) => c.toUpperCase())} = ${exportString};`

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -108,19 +108,14 @@ export function cli(argv, resolvedApplicationInitializer) {
     });
 
     // Create base TypesScript files
-    ["config/locales/en/translation/main-state.ts"].forEach(filePath => {
+    [
+      { filePath: "config/locales/en/translation/main-state.ts", exportString: "{}" },
+      { filePath: "config/locales/en/utterances/invokeGenericIntent.ts", exportString: "[]" },
+    ].forEach(({ filePath, exportString }) => {
       console.log("Creating " + filePath + "..");
       fs.writeFileSync(
         projectPath + filePath,
-        `export const ${path.basename(filePath, path.extname(filePath)).replace(/[\-]+([a-z])/gi, (m, c) => c.toUpperCase())} = {};`
-      );
-    });
-
-    ["config/locales/en/utterances/invokeGenericIntent.ts"].forEach(filePath => {
-      console.log("Creating " + filePath + "..");
-      fs.writeFileSync(
-        projectPath + filePath,
-        `export const ${path.basename(filePath, path.extname(filePath)).replace(/[\-]+([a-z])/gi, (m, c) => c.toUpperCase())} = [];`
+        `export const ${path.basename(filePath, path.extname(filePath)).replace(/[\-]+([a-z])/gi, (m, c) => c.toUpperCase())} = ${exportString};`
       );
     });
   };

--- a/src/components/i18n/descriptor.ts
+++ b/src/components/i18n/descriptor.ts
@@ -5,6 +5,7 @@ import { arraySplitter } from "./plugins/array-returns-sample.plugin";
 import { Configuration } from "./private-interfaces";
 
 import { injectionNames, Logger } from "../../assistant-source";
+import { LocalesLoader } from "../unifier/public-interfaces";
 import { I18nContext } from "./context";
 import { InterpolationResolver as InterpolationResolverImpl } from "./interpolation-resolver";
 import { InterpolationResolver, TranslateHelper, TranslateHelperFactory, TranslateValuesFor } from "./public-interfaces";
@@ -37,6 +38,7 @@ export const descriptor: ComponentDescriptor<Configuration.Defaults> = {
           return new I18nextWrapper(
             context.container.get<Component<Configuration.Runtime>>(getMetaInjectionName("core:i18n")),
             context.container.get<Logger>(injectionNames.logger),
+            context.container.get<LocalesLoader>(injectionNames.localesLoader),
             false
           );
         })

--- a/src/components/root/app-deployment.ts
+++ b/src/components/root/app-deployment.ts
@@ -1,5 +1,6 @@
 import * as fs from "fs";
 import { Container } from "inversify-components";
+import * as path from "path";
 import { componentInterfaces } from "./private-interfaces";
 import { CLIDeploymentExtension } from "./public-interfaces";
 
@@ -14,6 +15,6 @@ export class DeploymentApplication {
   public async execute(container: Container): Promise<void> {
     // Get all bound deployments and execute them
     const deployments = container.inversifyInstance.getAll<CLIDeploymentExtension>(componentInterfaces.deployments);
-    await Promise.all(deployments.map(deployment => deployment.execute(`${this.buildDir}/${this.buildTimeStamp}`)));
+    await Promise.all(deployments.map(deployment => deployment.execute(path.join(this.buildDir, this.buildTimeStamp.toString()))));
   }
 }

--- a/src/components/unifier/locales-loader.ts
+++ b/src/components/unifier/locales-loader.ts
@@ -29,21 +29,21 @@ export class LocalesLoader implements ILocalesLoader {
    * Return the user defined utterance templates for each language found in locales folder
    */
   public getUtteranceTemplates(): PlatformGenerator.Multilingual<{ [intent: string]: string[] }> {
-    return Object.entries(this.getLocales() || {}).reduce((utterances, [lang, locale]) => ({ ...utterances, [lang]: locale.utterances }), {});
+    return this.extractNamespace("utterances");
   }
 
   /**
    * Return the user defined entities for each language found in locales folder
    */
   public getCustomEntities(): PlatformGenerator.Multilingual<PlatformGenerator.CustomEntityMapping> {
-    return Object.entries(this.getLocales() || {}).reduce((entities, [lang, locale]) => ({ ...entities, [lang]: locale.entities }), {});
+    return this.extractNamespace("entities");
   }
 
   /**
    * Return the user defined translations for each language found in locales folder
    */
   public getTranslations() {
-    return Object.entries(this.getLocales() || {}).reduce((translations, [lang, locale]) => ({ ...translations, [lang]: locale.translation }), {});
+    return this.extractNamespace("translation");
   }
 
   /**
@@ -56,6 +56,14 @@ export class LocalesLoader implements ILocalesLoader {
     }
 
     return (this.locales = LocalesLoader.requireDir(this.configuration.utterancePath || path.join(process.cwd(), "js", "config", "locales")));
+  }
+
+  /**
+   * Extract namespace from result of `getLocales`.
+   * @param {string} ns Namespace to be extracted from locales
+   */
+  private extractNamespace(ns: string): PlatformGenerator.Multilingual<any> {
+    return Object.entries(this.getLocales() || {}).reduce((namespace, [lang, locale]) => ({ ...namespace, [lang]: locale[ns] }), {});
   }
 
   /**

--- a/src/components/unifier/locales-loader.ts
+++ b/src/components/unifier/locales-loader.ts
@@ -14,8 +14,10 @@ import { LocalesLoader as ILocalesLoader, PlatformGenerator } from "./public-int
 
 @injectable()
 export class LocalesLoader implements ILocalesLoader {
+  // An array with all extensions that can be loaded by the current environment (e.g. [ts, tsx, js, json, node] for ts-node)
   private static loadableExtensions = Object.keys(require.extensions).map(ext => ext.replace(/\.([a-z]+)$/i, "$1"));
 
+  // Current configuration for "unifier" component
   private configuration: Configuration.Runtime;
 
   // For caching values read from file system
@@ -55,7 +57,8 @@ export class LocalesLoader implements ILocalesLoader {
    */
   public getLocales(): PlatformGenerator.Multilingual<{ translation: any; entities: any; utterances: any }> | undefined {
     if (this.locales !== undefined) {
-      // Use cached data
+      // Use cached data, which is loaded once per instance of LocalesLoader to be able to update changed data, but
+      // on the other hand not excessively read data from files for each function call.
       return this.locales;
     }
 

--- a/src/components/unifier/public-interfaces.ts
+++ b/src/components/unifier/public-interfaces.ts
@@ -484,4 +484,8 @@ export interface LocalesLoader {
   getUtteranceTemplates(): PlatformGenerator.Multilingual<{ [intent: string]: string[] }>;
   /** Returns all custom entity mappings for all languages */
   getCustomEntities(): PlatformGenerator.Multilingual<PlatformGenerator.CustomEntityMapping>;
+  /** Returns all translations for all languages */
+  getTranslations(): PlatformGenerator.Multilingual<{}>;
+  /** Returns all locales for all languages */
+  getLocales(): PlatformGenerator.Multilingual<{}> | undefined;
 }


### PR DESCRIPTION
Lädt alle Locales (translations, utterances, entities) aus dem in der Config angegebenen Order. Es wird ein Objekt erzeugt, das der Dateistruktur entspricht. Dazu wird folgende Logik angewandt:

* Das Root Verzeichnis mit all seinen Dateien und Ordnern wird importiert
* Basisdateinamen (ohne Endung) bzw. Ordnernamen werden als Keys im Objekt verwendet
* Dateien in Unterordnern befinden sich auch in Subobjekten
* Dateien und Ordner mit identischem Namen (ohne Endung) werden gemergt, wobei die Datei Priorität hat
* Haben Dateien einen `default` export wird nur dieser extrahiert, dafür aber "transparent"
* Haben Dateien keinen `default` export, besitzen jedoch einen export mit dem Dateinamen (oder camelcased), wird nur dieser exportiert, dafür aber "transparent"
* Exportiert die Datei weder `default` noch den Dateinamen wird alles andere exportiert.

Beispiel:

Die Ergebnisse aus _translation.ts_ und dem Ordner _translation_ werden zu einem Objekt gemergt. _main-state.ts_ und _translation.ts_ exportieren ihre Objekte unmittelbar, da sie entweder einen default export verwenden oder den Dateinamen. Letzteres erlaubt eine Typzuweisung ohne Casting. In Fall von _utterances.ts_ werden alles exports tatsächlich exportiert, da weder der Dateiname noch ein default export Verwendung finden.

_./locales/en/translation.ts_
```
export default { 
    fallbackResponse: []
}
```

_./locales/en/translation/main-state.ts_
```
export const mainState = {
  invokeGenericIntent: []
}
```

_./locales/en/utterances.ts_
```
export const invokeGenericIntent = [];
```

Locales Objekt:
```
{
  en: {
    translation: {
      fallbackResponse: [],
      mainState: {
        invokeGenericIntent: []
      }
    },
    utterances: {
      invokeGenericIntent: []
    }
  }
}
```