### PR TITLE
Suggestion for translation autocompletion option

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -107,7 +107,7 @@ export function cli(argv, resolvedApplicationInitializer) {
     });
 
     // Create empty json files
-    ["config/locales/en/translation/main-state.ts"].forEach(filePath => {
+    ["config/locales/en/translations.ts", "config/locales/en/translation/main-state.ts"].forEach(filePath => {
       console.log("Creating " + filePath + "..");
       fs.writeFileSync(
         projectPath + filePath,

--- a/src/components/i18n/public-interfaces.ts
+++ b/src/components/i18n/public-interfaces.ts
@@ -1,7 +1,19 @@
 import { Configuration } from "./private-interfaces";
 
+type Without<T, U extends string> = { [P in Exclude<keyof T, U>]: never };
+export type TranslationLeaf<Platforms extends string> = string | string[] | { [platform in Platforms]: string | string[] };
+export type TranslationKeys<T extends {}, Platforms extends string> = {
+  [k in keyof Without<T, Platforms>]: T[k] extends TranslationLeaf<Platforms> ? string : TranslationKeys<T[k], Platforms>
+};
+
 /** Uses I18next to get translations for keys */
-export interface TranslateHelper {
+export interface TranslateHelper<Platforms extends string = never, Autocompletion extends {} = {}> {
+  /**
+   * Access translations as "pathed" in translation files. Final element, which is called leaf, is a function
+   * working in the same way as `t()`, but on the path already given.
+   */
+  tk(): TranslationKeys<Autocompletion, Platforms>;
+
   /**
    * Translates the given key using your json translations and a convention-over-configuration-approach.
    * First try is `currentState.currentIntent.platform.device`.

--- a/src/spec-helper.ts
+++ b/src/spec-helper.ts
@@ -140,7 +140,7 @@ export class SpecHelper {
     additionalExtractions = {},
     additionalRequestContext = {}
   ): Promise<MergedHandler> {
-    return platformSpecHelper.pretendIntentCalled(intentToCall, additionalExtractions, additionalRequestContext);
+    return (platformSpecHelper.pretendIntentCalled as any)(intentToCall, false, additionalExtractions, additionalRequestContext);
   }
 
   /** Runs state machine to execute prepared intent method and collects and return all reponse handler results afterwards */


### PR DESCRIPTION
To be tested with https://github.com/baflo/baflo-assistantjs-translation-completion-example

Introduces helper function `tk()` in `TranslateHelper` which allows browsing translation keys. Must be supported by an interface provided to `BaseState` as seen [here](https://github.com/baflo/baflo-assistantjs-translation-completion-example/blob/master/app/states/application.ts#L18)

Can be used in any state that extends `ApplicationState` and has a generic set, e.g. 

```ts
class MainState extends ApplicationState<"mainState">{
  public async invokeGenericIntent(machine: Transitionable) {
    // Allows to browse intents of this state
    this.t(this.tk().invokeGenericIntent.helloWorld);
  }
}
```

Additionally, if intent name is set to the `tk()` function, we can also browse translation keys of that intent:

```ts
  public async invokeGenericIntent(machine: Transitionable) {
    const tk = this.tk<"invokeGenericIntent">();

    // Allows to browse intents of this state and translation keys of the intent
    this.t(this.logger.info(this.tk().invokeGenericIntent.helloWorld));
  }
```